### PR TITLE
Adding links to JS, TS, React Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 - 📗&nbsp;&nbsp;[JavaScript Tutorial](https://www.javascripttutorial.net/)
 - 📘&nbsp;&nbsp;[JavaScript for Impatient Programmers](https://exploringjs.com/impatient-js/toc.html)
 - 📘&nbsp;&nbsp;[Just Javascript](https://justjavascript.com/)
+- 📘&nbsp;&nbsp;[JavaScript Roadmap](https://roadmap.sh/javascript)
 - 🎥&nbsp;&nbsp;[Complete JavaScript](https://www.udemy.com/course/the-complete-javascript-course/)
 - 🎥&nbsp;&nbsp;[Javascript Complete Guide](https://www.udemy.com/course/javascript-the-complete-guide-2020-beginner-advanced/)
 
@@ -80,6 +81,7 @@
 - 📗&nbsp;&nbsp;[TypeScript Tutorial](https://www.typescripttutorial.net/)
 - 📗&nbsp;&nbsp;[TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/intro.html)
 - 📘&nbsp;&nbsp;[Programming TypeScript](https://www.oreilly.com/library/view/programming-typescript/9781492037644/)
+- 📘&nbsp;&nbsp;[TypeScript Roadmap](https://roadmap.sh/typescript)
 - 🎥&nbsp;&nbsp;[Understanding typescript](https://www.udemy.com/course/understanding-typescript/)
 - 🎥&nbsp;&nbsp;[TypeScript Course by ui.dev](https://ui.dev/typescript/)
 
@@ -92,6 +94,7 @@
 - 📗&nbsp;&nbsp;[ReactJS docs (beta)](https://beta.reactjs.org/)
 - 📗&nbsp;&nbsp;[ReactJS Tutorials](https://reactjs.org/tutorial/tutorial.html)
 - 🎥&nbsp;&nbsp;[Scrimba - Learn React for free interactively](https://scrimba.com/learn/learnreact)
+- 📘&nbsp;&nbsp;[React Roadmap](https://roadmap.sh/react)
 
 <br>
 


### PR DESCRIPTION
Hi @sadanandpai,

I came across your repository [frontend-learning-kit](https://github.com/sadanandpai/frontend-learning-kit) and found it to be a valuable resource for Front-end enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["JavaScript Roadmap"](https://roadmap.sh/javascript), ["TypeScript Roadmap"](https://roadmap.sh/typescript) and ["React Roadmap"](https://roadmap.sh/react) . I took the initiative to submit a ["Pull Request"](https://github.com/sadanandpai/frontend-learning-kit/pull/20) adding it in respective sections.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz